### PR TITLE
Jwt 관련 예외 처리 클래스 및 로직 구현 PR

### DIFF
--- a/src/main/java/com/gdsc/petwalk/auth/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/gdsc/petwalk/auth/jwt/filter/JwtAuthorizationFilter.java
@@ -3,6 +3,8 @@ package com.gdsc.petwalk.auth.jwt.filter;
 import com.gdsc.petwalk.auth.jwt.service.JwtService;
 import com.gdsc.petwalk.domain.member.entity.Member;
 import com.gdsc.petwalk.domain.member.service.MemberService;
+import com.gdsc.petwalk.global.exception.ErrorCode;
+import com.gdsc.petwalk.global.exception.NotValidTokenException;
 import com.gdsc.petwalk.global.principal.PrincipalDetails;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -35,7 +37,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
 
         // 해당 경로로 시작하는 uri에 대해서는 filter를 거치지 않음
-        if (path.startsWith("/login") || path.startsWith("/oauth2")) {
+        if (path.startsWith("/login") || path.startsWith("/oauth2") || path.startsWith("/api/members")) {
             return true;
         }
 
@@ -50,12 +52,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         String accesstoken = request.getHeader("Accesstoken");
 
-        if(accesstoken == null){
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        if (accesstoken != null && jwtService.validateToken(accesstoken)) {
+        if (jwtService.validateToken(accesstoken)) {
             //JWT 토큰을 파싱해서 member 정보를 가져옴
             String email = jwtService.getEmail(accesstoken);
             Member member = memberService.findMemberByEmail(email);

--- a/src/main/java/com/gdsc/petwalk/auth/jwt/filter/JwtExceptionHandlerFilter.java
+++ b/src/main/java/com/gdsc/petwalk/auth/jwt/filter/JwtExceptionHandlerFilter.java
@@ -1,0 +1,43 @@
+package com.gdsc.petwalk.auth.jwt.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdsc.petwalk.global.exception.NotValidTokenException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (NotValidTokenException e){
+            HttpStatus httpStatus = e.getErrorCode().getHttpStatus();
+            String message = e.getErrorCode().getMessage();
+
+            Map<String, Object> jsonResponse = new HashMap<>();
+            jsonResponse.put("status", httpStatus.value());
+            jsonResponse.put("message", message);
+
+            response.setStatus(httpStatus.value());
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+
+            objectMapper.writeValue(response.getWriter(), jsonResponse);
+        }
+    }
+}

--- a/src/main/java/com/gdsc/petwalk/global/config/SecurityConfig.java
+++ b/src/main/java/com/gdsc/petwalk/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.gdsc.petwalk.auth.itself.handler.LoginFailureHandler;
 import com.gdsc.petwalk.auth.itself.handler.LoginSuccessHandler;
 import com.gdsc.petwalk.auth.itself.service.LoginService;
 import com.gdsc.petwalk.auth.jwt.filter.JwtAuthorizationFilter;
+import com.gdsc.petwalk.auth.jwt.filter.JwtExceptionHandlerFilter;
 import com.gdsc.petwalk.auth.jwt.service.JwtService;
 import com.gdsc.petwalk.auth.oauth2.handler.CustomOauth2SuccessHandler;
 import com.gdsc.petwalk.auth.oauth2.service.CustomOauth2UserService;
@@ -31,6 +32,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 public class SecurityConfig {
 
     private final JwtAuthorizationFilter jwtAuthorizationFilter;
+    private final JwtExceptionHandlerFilter jwtExceptionHandlerFilter;
     private final CustomOauth2UserService customOauth2UserService;
     private final LoginSuccessHandler loginSuccessHandler;
     private final LoginFailureHandler loginFailureHandler;
@@ -58,6 +60,7 @@ public class SecurityConfig {
                                 .successHandler(customOauth2SuccessHandler))
                         .addFilterAfter(customJsonUserPasswordAuthenticationFilter(), LogoutFilter.class)
                         .addFilterBefore(jwtAuthorizationFilter, CustomJsonUserPasswordAuthenticationFilter.class)
+                        .addFilterBefore(jwtExceptionHandlerFilter, JwtAuthorizationFilter.class)
                         .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                         .build();
     }

--- a/src/main/java/com/gdsc/petwalk/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdsc/petwalk/global/exception/ErrorCode.java
@@ -1,0 +1,30 @@
+package com.gdsc.petwalk.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    //401
+    EXPIRED_ACCESS_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED,
+            "Access token이 만료되었습니다. Refresh token을 사용하세요."),
+
+    EXPIRED_REFRESH_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED,
+            "Refresh token이 만료되었습니다. 다시 로그인하세요."),
+
+    NOT_VALID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED,
+            "유효하지 않은 JWT 토큰입니다."),
+
+    UNSUPPORTED_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED,
+            "지원되지 않는 JWT 토큰입니다."),
+
+    MISMATCH_CLAIMS_EXCEPTION(HttpStatus.UNAUTHORIZED,
+            "JWT 토큰의 클레임이 일치하지 않거나 토큰이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/com/gdsc/petwalk/global/exception/ExControllerAdvice.java
+++ b/src/main/java/com/gdsc/petwalk/global/exception/ExControllerAdvice.java
@@ -1,0 +1,11 @@
+package com.gdsc.petwalk.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ExControllerAdvice {
+    // 컨트롤러 단에서 발생하는 예외 처리
+
+}

--- a/src/main/java/com/gdsc/petwalk/global/exception/NotValidTokenException.java
+++ b/src/main/java/com/gdsc/petwalk/global/exception/NotValidTokenException.java
@@ -1,0 +1,34 @@
+package com.gdsc.petwalk.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class NotValidTokenException extends RuntimeException{
+
+    private ErrorCode errorCode;
+
+    public NotValidTokenException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public NotValidTokenException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public NotValidTokenException(String message, Throwable cause, ErrorCode errorCode) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public NotValidTokenException(Throwable cause, ErrorCode errorCode) {
+        super(cause);
+        this.errorCode = errorCode;
+    }
+
+    public NotValidTokenException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, ErrorCode errorCode) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.errorCode = errorCode;
+    }
+
+}


### PR DESCRIPTION
JwtService에서 사용하는 validateToken 메서드가 모두 NotValidTokenException을 반환하도록 수정(직접 만든 Custom Exception).

이때 NotValidTokenException에 생성자로 Errorcode 객체를 주입하여 에러에 따른 status과 message를 구체화 함.

JwtAuthorizationFilter단에서 발생하는 NotValidTokenException은 JwtExceptionHandlerFilter에서 처리할 수 있도록 함.

이를 위해 SecurityConfig에서 JwtExceptionHandlerFilter가 JwtAuthorizationFilter보다 먼저 작동하도록 필터 순서를 조금 조정.